### PR TITLE
RNAseQC: functionalize and lift from the notebook

### DIFF
--- a/depmapomics/config.py
+++ b/depmapomics/config.py
@@ -1,0 +1,13 @@
+RNASEQC_THRESHOLDS_LOWQUAL = {'minmapping': 0.85, 'minendmapping': 0.75, 'minefficiency': 0.75,
+                              'maxendmismatch': 0.02, 'maxmismatch': 0.02, 'minhighqual': 0.8,
+                              'minexon': 0.7, "maxambiguous": 0.05, "maxsplits": 0.1,
+                              "maxalt": 0.2, "maxchim": 0.05, "minreads": 20000000,
+                              "minlength": 80, "maxgenes": 35000, "mingenes": 12000}
+
+
+RNASEQC_THRESHOLDS_FAILED = {'minmapping': 0.7, 'minendmapping': 0.66, 'minefficiency': 0.6,
+                             'maxendmismatch': 0.02, 'maxmismatch': 0.02, 'minhighqual': 0.7,
+                             'minexon': 0.66, "maxambiguous": 0.1, "maxsplits": 0.1,
+                             "maxalt": 0.5, "maxchim": 0.2, "minreads": 20000000,
+                             "minlength": 80, "maxgenes": 35000, "mingenes": 10000}
+

--- a/depmapomics/helper.py
+++ b/depmapomics/helper.py
@@ -1,0 +1,33 @@
+from genepy import rna
+from depmapomics.config import RNASEQC_THRESHOLDS_LOWQUAL, RNASEQC_THRESHOLDS_FAILED
+
+import pandas as pd
+
+def plot_rnaseqc_results(workspace, samplelist):
+    rnaqc = getQC(workspace=workspace, only=samplelist, qcname="rnaseqc2_metrics")
+    assert pd.Series(rnaqc).map(lambda x: x[0]).notnull().all()
+
+    import numpy as np
+    qcs = pd.DataFrame()
+    for k,val in rnaqc.items():
+        if val[0] is not np.nan:
+            qcs = pd.concat([qcs, pd.read_csv(val[0],sep='\t', index_col=0)],axis=1)
+    qcs = qcs[~((qcs.mean(1)==1.0) | (qcs.mean(1)==0.0))]
+
+    # qcs = pd.Series(rnaqc).map(lambda x: x[0]).dropna()
+    # qcs = qcs.apply(lambda x: pd.read_csv(x, sep='\t', index_col=0))
+    # qcs = pd.concat(qcs.tolist(), axis=1)
+    # qcs = qcs[~((qcs.mean(1)==1.0) | (qcs.mean(1)==0.0))]
+
+    print('Low quality samples')
+    import sys
+    sys.stdout.flush()
+
+    lowqual = rna.filterRNAfromQC(qcs, thresholds=RNASEQC_THRESHOLDS_LOWQUAL,
+                                  folder='/tmp/lowqual/', plot=True, qant1=0.1, qant3=0.9)
+    print('Failed QC samples')
+    sys.stdout.flush()
+    failed = rna.filterRNAfromQC(qcs, thresholds=RNASEQC_THRESHOLDS_FAILED,
+                                 folder='/tmp/failed', plot=True, qant1=0.07, qant3=0.93)
+
+    return qcs, lowqual, failed

--- a/depmapomics/helper.py
+++ b/depmapomics/helper.py
@@ -3,7 +3,7 @@ from depmapomics.config import RNASEQC_THRESHOLDS_LOWQUAL, RNASEQC_THRESHOLDS_FA
 
 import pandas as pd
 
-def plot_rnaseqc_results(workspace, samplelist):
+def plot_rnaseqc_results(workspace, samplelist, output_path = 'data/rna_qc_plots/'):
     rnaqc = getQC(workspace=workspace, only=samplelist, qcname="rnaseqc2_metrics")
     assert pd.Series(rnaqc).map(lambda x: x[0]).notnull().all()
 
@@ -24,10 +24,12 @@ def plot_rnaseqc_results(workspace, samplelist):
     sys.stdout.flush()
 
     lowqual = rna.filterRNAfromQC(qcs, thresholds=RNASEQC_THRESHOLDS_LOWQUAL,
-                                  folder='/tmp/lowqual/', plot=True, qant1=0.1, qant3=0.9)
+                                  folder='{}/lowqual/'.format(output_path), plot=True,
+                                  qant1=0.1, qant3=0.9)
     print('Failed QC samples')
     sys.stdout.flush()
     failed = rna.filterRNAfromQC(qcs, thresholds=RNASEQC_THRESHOLDS_FAILED,
-                                 folder='/tmp/failed', plot=True, qant1=0.07, qant3=0.93)
+                                 folder='{}/lowqual/'.format(output_path), plot=True,
+                                 qant1=0.07, qant3=0.93)
 
     return qcs, lowqual, failed

--- a/depmapomics/helper.py
+++ b/depmapomics/helper.py
@@ -1,19 +1,21 @@
 from genepy import rna
 from depmapomics.config import RNASEQC_THRESHOLDS_LOWQUAL, RNASEQC_THRESHOLDS_FAILED
+from src.CCLE_postp_function import getQC
 
 import pandas as pd
 
-def plot_rnaseqc_results(workspace, samplelist, output_path = 'data/rna_qc_plots/'):
+def plot_rnaseqc_results(workspace, samplelist, output_path='data/rna_qc_plots/'):
     rnaqc = getQC(workspace=workspace, only=samplelist, qcname="rnaseqc2_metrics")
     assert pd.Series(rnaqc).map(lambda x: x[0]).notnull().all()
 
     import numpy as np
     qcs = pd.DataFrame()
-    for k,val in rnaqc.items():
+    for k, val in rnaqc.items():
         if val[0] is not np.nan:
-            qcs = pd.concat([qcs, pd.read_csv(val[0],sep='\t', index_col=0)],axis=1)
-    qcs = qcs[~((qcs.mean(1)==1.0) | (qcs.mean(1)==0.0))]
+            qcs = pd.concat([qcs, pd.read_csv(val[0], sep='\t', index_col=0)], axis=1)
+    qcs = qcs[~((qcs.mean(1) == 1.0) | (qcs.mean(1) == 0.0))]
 
+    # pandas implementation
     # qcs = pd.Series(rnaqc).map(lambda x: x[0]).dropna()
     # qcs = qcs.apply(lambda x: pd.read_csv(x, sep='\t', index_col=0))
     # qcs = pd.concat(qcs.tolist(), axis=1)

--- a/depmapomics/helper.py
+++ b/depmapomics/helper.py
@@ -1,8 +1,11 @@
-from genepy import rna
-from depmapomics.config import RNASEQC_THRESHOLDS_LOWQUAL, RNASEQC_THRESHOLDS_FAILED
-from src.CCLE_postp_function import getQC
+import sys
 
 import pandas as pd
+from genepy import rna
+from src.CCLE_postp_function import getQC
+
+from depmapomics.config import (RNASEQC_THRESHOLDS_FAILED,
+                                RNASEQC_THRESHOLDS_LOWQUAL)
 
 def plot_rnaseqc_results(workspace, samplelist, output_path='data/rna_qc_plots/'):
     rnaqc = getQC(workspace=workspace, only=samplelist, qcname="rnaseqc2_metrics")
@@ -22,7 +25,7 @@ def plot_rnaseqc_results(workspace, samplelist, output_path='data/rna_qc_plots/'
     # qcs = qcs[~((qcs.mean(1)==1.0) | (qcs.mean(1)==0.0))]
 
     print('Low quality samples')
-    import sys
+
     sys.stdout.flush()
 
     lowqual = rna.filterRNAfromQC(qcs, thresholds=RNASEQC_THRESHOLDS_LOWQUAL,

--- a/src/CCLE_postp_function.py
+++ b/src/CCLE_postp_function.py
@@ -20,11 +20,11 @@ tc = TaigaClient()
 import os
 import ipdb
 import sys
-print("you need to have JKBio in your path:\ne.g. have installed JKBio in the same folder as ccle_processing")
-from JKBio import terra
-from JKBio import sequencing as seq
-from JKBio.utils import helper as h
-from JKBio.google import gcp
+
+from genepy import terra
+from genepy import sequencing as seq
+from genepy.utils import helper as h
+from genepy.google import gcp
 from collections import Counter
 from gsheets import Sheets
 import seaborn as sns


### PR DESCRIPTION
This is a function that combines all the rnaseq qc steps  (to be lifted out of the notebook in the future). 

Example code:

```python
from depmapomics.helper import plot_rnaseqc_results

samplelist = samples.index.tolist()
qcs, lowqual, failed = plot_rnaseqc_results(workspace, samplelist, output_path='/tmp/rna_qc_plots/')
```

